### PR TITLE
Require webpack-encore in dev only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "sylius/sylius": "~1.3",
         "symfony/http-kernel": "^4.3",
         "sylius/ui-bundle": "^1.6",
-        "symfony/webpack-encore-bundle": "^1.7",
         "ext-json": "*",
         "ext-intl": "*",
         "twig/extensions": "^1.5"
@@ -37,7 +36,8 @@
         "symfony/dotenv": "^4.3",
         "symfony/intl": "^3.4|^4.3",
         "symfony/web-profiler-bundle": "^3.4|^4.3",
-        "symfony/web-server-bundle": "^3.4|^4.3"
+        "symfony/web-server-bundle": "^3.4|^4.3",
+        "symfony/webpack-encore-bundle": "^1.7"
     },
     "prefer-stable": true,
     "autoload": {


### PR DESCRIPTION
Webpack Encore was before in the require fragment of the `composer.json`.
Therefor it was added when we required the plugin on a Sylius project.
And we don't want that.
