### PR TITLE
Allow to get UIElements and render them individually

### DIFF
--- a/.github/workflows/recipe.yaml
+++ b/.github/workflows/recipe.yaml
@@ -44,14 +44,14 @@ jobs:
         id: cache-composer
         with:
           path: /home/runner/.composer/cache
-          key: composer-php:${{ matrix.php }}-${{ github.sha }}
-          restore-keys: composer-php:${{ matrix.php }}-
+          key: composer2-php:${{ matrix.php }}-${{ github.sha }}
+          restore-keys: composer2-php:${{ matrix.php }}-
 
       - run: mkdir -p /home/runner/.composer/cache
         if: steps.cache-composer.outputs.cache-hit != 'true'
 
-      - name: Composer v1
-        run: sudo composer self-update --1 
+      - name: Composer v2
+        run: sudo composer self-update --2 
 
       - name: Composer Github Auth
         run: composer config -g github-oauth.github.com ${{ github.token }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,8 +41,8 @@ jobs:
         id: cache-composer
         with:
           path: /home/runner/.composer/cache
-          key: composer-php:${{ matrix.php }}-${{ github.sha }}
-          restore-keys: composer-php:${{ matrix.php }}-
+          key: composer2-php:${{ matrix.php }}-${{ github.sha }}
+          restore-keys: composer2-php:${{ matrix.php }}-
 
       - run: mkdir -p /home/runner/.composer/cache
         if: steps.cache-composer.outputs.cache-hit != 'true'

--- a/README.md
+++ b/README.md
@@ -82,6 +82,28 @@ To display the content of the rich editor field you must call the twig filter:
 
 You can see an example in the [test application](/tests/Application/templates/bundles/SyliusShopBundle/Product/Show/Tabs/Details/_description.html.twig)
 
+### Custom rendering of elements
+
+You can also render your elements with some custom DOM around that. To do so, you have access to a twig filter that 
+gives you the elements list :
+
+```twig
+{% set elements = content|monsieurbiz_richeditor_get_elements %}
+```
+
+And then you can either render them all : 
+
+```twig
+{{ monsieurbiz_richeditor_render_elements(elements) }}
+```
+
+Or one buy one :
+```twig
+{% for element in elements %}
+    {{ monsieurbiz_richeditor_render_element(element) }}
+{% endfor %}
+```
+
 ### Filter the elements
 
 If you want to filter the elements which are available for your field, you can use the `tags` option when you build your form.  

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ And then you can either render them all :
 {{ elements|monsieurbiz_richeditor_render_elements }}
 ```
 
-Or one buy one :
+Or one by one :
 ```twig
 {% for element in elements %}
     {{ element|monsieurbiz_richeditor_render_element }}

--- a/README.md
+++ b/README.md
@@ -88,19 +88,19 @@ You can also render your elements with some custom DOM around that. To do so, yo
 gives you the elements list :
 
 ```twig
-{% set elements = content|monsieurbiz_richeditor_get_elements %}
+{% set elements = monsieurbiz_richeditor_get_elements(content) %}
 ```
 
 And then you can either render them all : 
 
 ```twig
-{{ monsieurbiz_richeditor_render_elements(elements) }}
+{{ elements|monsieurbiz_richeditor_render_elements }}
 ```
 
 Or one buy one :
 ```twig
 {% for element in elements %}
-    {{ monsieurbiz_richeditor_render_element(element) }}
+    {{ element|monsieurbiz_richeditor_render_element }}
 {% endfor %}
 ```
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -47,6 +47,8 @@ final class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('upload_directory')->end()
+                ->scalarNode('default_element')->defaultValue('monsieurbiz.html')->end()
+                ->scalarNode('default_element_data_field')->defaultValue('content')->end()
                 ->arrayNode('ui_elements')
                     ->useAttributeAsKey('code', false)
                     ->defaultValue([])

--- a/src/DependencyInjection/MonsieurBizSyliusRichEditorExtension.php
+++ b/src/DependencyInjection/MonsieurBizSyliusRichEditorExtension.php
@@ -29,6 +29,8 @@ final class MonsieurBizSyliusRichEditorExtension extends Extension
         $config = $this->processConfiguration(/** @scrutinizer ignore-type */ $configuration, $config);
         $container->setParameter('monsieurbiz.richeditor.config.ui_elements', $config['ui_elements']);
         $container->setParameter('monsieurbiz.richeditor.config.upload_directory', $config['upload_directory']);
+        $container->setParameter('monsieurbiz.richeditor.config.default_element', $config['default_element']);
+        $container->setParameter('monsieurbiz.richeditor.config.default_element_data_field', $config['default_element_data_field']);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yaml');

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -3,6 +3,10 @@ services:
         autowire: true
         autoconfigure: true
         public: false
+    
+        bind:
+            string $monsieurbizRicheditorDefaultElement: '%monsieurbiz.richeditor.config.default_element%'
+            string $monsieurbizRicheditorDefaultElementDataField: '%monsieurbiz.richeditor.config.default_element_data_field%'
 
     MonsieurBiz\SyliusRichEditorPlugin\Controller\:
         resource: '../../Controller'

--- a/src/Resources/views/Admin/app.html.twig
+++ b/src/Resources/views/Admin/app.html.twig
@@ -132,8 +132,8 @@
                 '{{ url("monsieurbiz_richeditor_admin_form_create", {"code": "__CODE__"})|e('js') }}',
                 '{{ url("monsieurbiz_richeditor_admin_form_edit", {"code": "__CODE__"})|e('js') }}',
                 '{{ url("monsieurbiz_richeditor_admin_form_render_elements")|e('js') }}',
-                'monsieurbiz.html',
-                'content'
+                {{ monsieurbiz_richeditor_get_default_element() }},
+                {{ monsieurbiz_richeditor_get_default_element_data_field() }}
             );
             editor.manager = new MonsieurBizRichEditorManager(config);
         });

--- a/src/Twig/RichEditorExtension.php
+++ b/src/Twig/RichEditorExtension.php
@@ -114,6 +114,7 @@ final class RichEditorExtension extends AbstractExtension
             // If the JSON decode failed, return a new UIElement with default configuration
             return [
                 'type' => $this->getDefaultElement(),
+                'data' => $content,
             ];
         }
 

--- a/src/Twig/RichEditorExtension.php
+++ b/src/Twig/RichEditorExtension.php
@@ -115,7 +115,6 @@ final class RichEditorExtension extends AbstractExtension
             // If the JSON decode failed, return a new UIElement with default configuration
             return [
                 'type' => $this->getDefaultElement(),
-                'data' => $content,
             ];
         }
 

--- a/src/Twig/RichEditorExtension.php
+++ b/src/Twig/RichEditorExtension.php
@@ -29,6 +29,7 @@ final class RichEditorExtension extends AbstractExtension
     private RegistryInterface $uiElementRegistry;
 
     private Environment $twig;
+
     private string $defaultElement;
 
     private string $defaultElementDataField;
@@ -113,7 +114,7 @@ final class RichEditorExtension extends AbstractExtension
         if (!\is_array($elements)) {
             // If the JSON decode failed, return a new UIElement with default configuration
             return [
-                'type' => $this->getDefaultUiElement(),
+                'type' => $this->getDefaultElement(),
                 'data' => $content,
             ];
         }

--- a/src/Twig/RichEditorExtension.php
+++ b/src/Twig/RichEditorExtension.php
@@ -29,6 +29,7 @@ final class RichEditorExtension extends AbstractExtension
     private RegistryInterface $uiElementRegistry;
 
     private Environment $twig;
+
     private string $defaultElement;
 
     private string $defaultElementDataField;
@@ -59,7 +60,7 @@ final class RichEditorExtension extends AbstractExtension
     public function getFilters(): array
     {
         return [
-            new TwigFilter('monsieurbiz_richeditor_render_field', [$this, 'renderRichEditorField'], ['is_safe' => ['html']]),
+            new TwigFilter('monsieurbiz_richeditor_render_field', [$this, 'renderField'], ['is_safe' => ['html']]),
             new TwigFilter('monsieurbiz_richeditor_render_elements', [$this, 'renderElements'], ['is_safe' => ['html']]),
             new TwigFilter('monsieurbiz_richeditor_render_element', [$this, 'renderElement'], ['is_safe' => ['html']]),
         ];
@@ -73,7 +74,7 @@ final class RichEditorExtension extends AbstractExtension
         return [
             new TwigFunction('monsieurbiz_richeditor_list_elements', [$this, 'listUiElements'], ['is_safe' => ['html', 'js']]),
             new TwigFunction('monsieurbiz_richeditor_youtube_link', [$this, 'convertYoutubeEmbeddedLink'], ['is_safe' => ['html', 'js']]),
-            new TwigFunction('monsieurbiz_richeditor_get_elements', [$this, 'getRichEditorFieldElements'], ['is_safe' => ['html']]),
+            new TwigFunction('monsieurbiz_richeditor_get_elements', [$this, 'getElements'], ['is_safe' => ['html']]),
             new TwigFunction('monsieurbiz_richeditor_get_default_element', [$this, 'getDefaultElement'], ['is_safe' => ['html']]),
             new TwigFunction('monsieurbiz_richeditor_get_default_element_data_field', [$this, 'getDefaultElementDataField'], ['is_safe' => ['html']]),
         ];
@@ -88,7 +89,7 @@ final class RichEditorExtension extends AbstractExtension
      *
      * @return string
      */
-    public function renderRichEditorField(string $content): string
+    public function renderField(string $content): string
     {
         $elements = json_decode($content, true);
         if (!\is_array($elements)) {
@@ -107,7 +108,7 @@ final class RichEditorExtension extends AbstractExtension
      *
      * @return array
      */
-    public function getRichEditorFieldElements(string $content): array
+    public function getElements(string $content): array
     {
         $elements = json_decode($content, true);
         if (!\is_array($elements)) {

--- a/src/Twig/RichEditorExtension.php
+++ b/src/Twig/RichEditorExtension.php
@@ -114,7 +114,7 @@ final class RichEditorExtension extends AbstractExtension
             // If the JSON decode failed, return a new UIElement with default configuration
             return [
                 'type' => $this->getDefaultElement(),
-                'data' => [$this->getDefaultElementDataField()  => $content],
+                'data' => [$this->getDefaultElementDataField() => $content],
             ];
         }
 

--- a/src/Twig/RichEditorExtension.php
+++ b/src/Twig/RichEditorExtension.php
@@ -30,18 +30,28 @@ final class RichEditorExtension extends AbstractExtension
 
     private Environment $twig;
 
+    private string $defaultElement;
+
+    private string $defaultElementDataField;
+
     /**
      * RichEditorExtension constructor.
      *
      * @param RegistryInterface $uiElementRegistry
      * @param Environment $twig
+     * @param string $monsieurbizRicheditorDefaultElement
+     * @param string $monsieurbizRicheditorDefaultElementDataField
      */
     public function __construct(
         RegistryInterface $uiElementRegistry,
-        Environment $twig
+        Environment $twig,
+        string $monsieurbizRicheditorDefaultElement,
+        string $monsieurbizRicheditorDefaultElementDataField
     ) {
         $this->uiElementRegistry = $uiElementRegistry;
         $this->twig = $twig;
+        $this->defaultElement = $monsieurbizRicheditorDefaultElement;
+        $this->defaultElementDataField = $monsieurbizRicheditorDefaultElementDataField;
     }
 
     /**
@@ -65,6 +75,8 @@ final class RichEditorExtension extends AbstractExtension
             new TwigFunction('monsieurbiz_richeditor_list_elements', [$this, 'listUiElements'], ['is_safe' => ['html', 'js']]),
             new TwigFunction('monsieurbiz_richeditor_youtube_link', [$this, 'convertYoutubeEmbeddedLink'], ['is_safe' => ['html', 'js']]),
             new TwigFunction('monsieurbiz_richeditor_get_elements', [$this, 'getRichEditorFieldElements'], ['is_safe' => ['html']]),
+            new TwigFunction('monsieurbiz_richeditor_get_default_element', [$this, 'getDefaultElement'], ['is_safe' => ['html']]),
+            new TwigFunction('monsieurbiz_richeditor_get_default_element_data_field', [$this, 'getDefaultElementDataField'], ['is_safe' => ['html']]),
         ];
     }
 
@@ -100,7 +112,11 @@ final class RichEditorExtension extends AbstractExtension
     {
         $elements = json_decode($content, true);
         if (!\is_array($elements)) {
-            return [$elements];
+            // If the JSON decode failed, return a new UIElement with default configuration
+            return [
+                'type' => $this->getDefaultUiElement(),
+                'data' => $content,
+            ];
         }
 
         return $elements;
@@ -186,5 +202,15 @@ final class RichEditorExtension extends AbstractExtension
         }
 
         return sprintf('https://www.youtube.com/embed/%s', $matches[1]);
+    }
+
+    public function getDefaultElement(): string
+    {
+        return $this->defaultElement;
+    }
+
+    public function getDefaultElementDataField(): string
+    {
+        return $this->defaultElementDataField;
     }
 }

--- a/src/Twig/RichEditorExtension.php
+++ b/src/Twig/RichEditorExtension.php
@@ -115,7 +115,7 @@ final class RichEditorExtension extends AbstractExtension
             // If the JSON decode failed, return a new UIElement with default configuration
             return [
                 'type' => $this->getDefaultElement(),
-                'data' => $content,
+                'data' => [$this->getDefaultElementDataField()  => $content],
             ];
         }
 

--- a/src/Twig/RichEditorExtension.php
+++ b/src/Twig/RichEditorExtension.php
@@ -26,15 +26,9 @@ use Twig\TwigFunction;
 
 final class RichEditorExtension extends AbstractExtension
 {
-    /**
-     * @var RegistryInterface
-     */
-    private $uiElementRegistry;
+    private RegistryInterface $uiElementRegistry;
 
-    /**
-     * @var Environment
-     */
-    private $twig;
+    private Environment $twig;
 
     /**
      * RichEditorExtension constructor.
@@ -53,21 +47,24 @@ final class RichEditorExtension extends AbstractExtension
     /**
      * @return TwigFilter[]
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('monsieurbiz_richeditor_render_field', [$this, 'renderRichEditorField'], ['is_safe' => ['html']]),
+            new TwigFilter('monsieurbiz_richeditor_get_elements', [$this, 'getRichEditorFieldElements'], ['is_safe' => ['html']]),
         ];
     }
 
     /**
      * @return array|TwigFunction[]
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('monsieurbiz_richeditor_list_elements', [$this, 'listUiElements'], ['is_safe' => ['html', 'js']]),
             new TwigFunction('monsieurbiz_richeditor_youtube_link', [$this, 'convertYoutubeEmbeddedLink'], ['is_safe' => ['html', 'js']]),
+            new TwigFunction('monsieurbiz_richeditor_render_elements', [$this, 'renderElements'], ['is_safe' => ['html']]),
+            new TwigFunction('monsieurbiz_richeditor_render_element', [$this, 'renderElement'], ['is_safe' => ['html']]),
         ];
     }
 
@@ -80,7 +77,7 @@ final class RichEditorExtension extends AbstractExtension
      *
      * @return string
      */
-    public function renderRichEditorField(string $content)
+    public function renderRichEditorField(string $content): string
     {
         $elements = json_decode($content, true);
         if (!\is_array($elements)) {
@@ -88,6 +85,25 @@ final class RichEditorExtension extends AbstractExtension
         }
 
         return $this->renderElements($elements);
+    }
+
+    /**
+     * @param string $content
+     *
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
+     *
+     * @return array
+     */
+    public function getRichEditorFieldElements(string $content): array
+    {
+        $elements = json_decode($content, true);
+        if (!\is_array($elements)) {
+            return [$elements];
+        }
+
+        return $elements;
     }
 
     /**
@@ -99,7 +115,7 @@ final class RichEditorExtension extends AbstractExtension
      *
      * @return string
      */
-    private function renderElements(array $elements): string
+    public function renderElements(array $elements): string
     {
         $html = '';
         foreach ($elements as $element) {
@@ -123,7 +139,7 @@ final class RichEditorExtension extends AbstractExtension
      *
      * @return string
      */
-    private function renderElement(array $element): string
+    public function renderElement(array $element): string
     {
         if (!isset($element['code'])) {
             if (!isset($element['type'], $element['fields'])) {

--- a/src/Twig/RichEditorExtension.php
+++ b/src/Twig/RichEditorExtension.php
@@ -51,7 +51,8 @@ final class RichEditorExtension extends AbstractExtension
     {
         return [
             new TwigFilter('monsieurbiz_richeditor_render_field', [$this, 'renderRichEditorField'], ['is_safe' => ['html']]),
-            new TwigFilter('monsieurbiz_richeditor_get_elements', [$this, 'getRichEditorFieldElements'], ['is_safe' => ['html']]),
+            new TwigFilter('monsieurbiz_richeditor_render_elements', [$this, 'renderElements'], ['is_safe' => ['html']]),
+            new TwigFilter('monsieurbiz_richeditor_render_element', [$this, 'renderElement'], ['is_safe' => ['html']]),
         ];
     }
 
@@ -63,8 +64,7 @@ final class RichEditorExtension extends AbstractExtension
         return [
             new TwigFunction('monsieurbiz_richeditor_list_elements', [$this, 'listUiElements'], ['is_safe' => ['html', 'js']]),
             new TwigFunction('monsieurbiz_richeditor_youtube_link', [$this, 'convertYoutubeEmbeddedLink'], ['is_safe' => ['html', 'js']]),
-            new TwigFunction('monsieurbiz_richeditor_render_elements', [$this, 'renderElements'], ['is_safe' => ['html']]),
-            new TwigFunction('monsieurbiz_richeditor_render_element', [$this, 'renderElement'], ['is_safe' => ['html']]),
+            new TwigFunction('monsieurbiz_richeditor_get_elements', [$this, 'getRichEditorFieldElements'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/Twig/RichEditorExtension.php
+++ b/src/Twig/RichEditorExtension.php
@@ -29,7 +29,6 @@ final class RichEditorExtension extends AbstractExtension
     private RegistryInterface $uiElementRegistry;
 
     private Environment $twig;
-
     private string $defaultElement;
 
     private string $defaultElementDataField;


### PR DESCRIPTION
This PR adds 1 new Twig FIlter to get all blocks of a RichEditorField
and 2 functions to render elements either from an array of elements, or one by one.

This allows to render any element with a better customization (like allow to surround with custom DOM elements)