### PR TITLE
Youtube url can contain - in code

### DIFF
--- a/src/Validator/Constraints/YoutubeUrlValidator.php
+++ b/src/Validator/Constraints/YoutubeUrlValidator.php
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class YoutubeUrlValidator extends ConstraintValidator
 {
-    public const YOUTUBE_REGEX_VALIDATOR = '`^(?:https?://)?(?:www\.)?(?:youtu.be/|youtube\.com/(?:watch(?:/|/?\?(?:\S*&)?v=)|embed/))([\w\d]+)$`';
+    public const YOUTUBE_REGEX_VALIDATOR = '`^(?:https?://)?(?:www\.)?(?:youtu.be/|youtube\.com/(?:watch(?:/|/?\?(?:\S*&)?v=)|embed/))([\w\d-]+)$`';
 
     public function validate($value, Constraint $constraint): void
     {


### PR DESCRIPTION
Hello,

A little fix because code of video of Youtube can contain `-` and the regex reject it.
https://www.youtube.com/watch?v=yy-Xd740OsI&t=1s

Regards

PS : It can also contain a `_` but the regex already takes it into account thanks to the `\w`.