### PR TITLE
Allow null to be passed as content to rendering methods in twig

### DIFF
--- a/src/Twig/RichEditorExtension.php
+++ b/src/Twig/RichEditorExtension.php
@@ -80,7 +80,7 @@ final class RichEditorExtension extends AbstractExtension
     }
 
     /**
-     * @param string $content
+     * @param string|null $content
      *
      * @throws LoaderError
      * @throws RuntimeError
@@ -88,8 +88,12 @@ final class RichEditorExtension extends AbstractExtension
      *
      * @return string
      */
-    public function renderField(string $content): string
+    public function renderField(?string $content): string
     {
+        if (null === $content) {
+            return '';
+        }
+
         $elements = json_decode($content, true);
         if (!\is_array($elements)) {
             return $content;
@@ -99,16 +103,16 @@ final class RichEditorExtension extends AbstractExtension
     }
 
     /**
-     * @param string $content
-     *
-     * @throws LoaderError
-     * @throws RuntimeError
-     * @throws SyntaxError
+     * @param string|null $content
      *
      * @return array
      */
-    public function getElements(string $content): array
+    public function getElements(?string $content): array
     {
+        if (null === $content) {
+            return [];
+        }
+
         $elements = json_decode($content, true);
         if (!\is_array($elements)) {
             // If the JSON decode failed, return a new UIElement with default configuration


### PR DESCRIPTION
Because sometimes you have a content which is `null`.

I don't want the system to fail in that specific case because it's nothing
to really worry about. If the content is `null` then we haven nothing to display.

