### PR TITLE
Prepare php8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "A Rich Editor plugin for Sylius.",
     "license": "MIT",
     "require": {
-        "php": "~7.4",
+        "php": "~7.4 || ^8.0",
         "ext-json": "*",
         "ext-intl": "*",
         "sylius/sylius": "^1.8"
@@ -31,8 +31,8 @@
         "mockery/mockery": "^1.4",
         "pamil/prophecy-common": "^0.1",
         "phpspec/phpspec": "^6.1",
-        "phpstan/phpstan": "0.12.29",
-        "phpstan/phpstan-doctrine": "0.12.16",
+        "phpstan/phpstan": "^0.12.29",
+        "phpstan/phpstan-doctrine": "^0.12.16",
         "phpstan/phpstan-webmozart-assert": "^0.12.7",
         "phpunit/phpunit": "^8.5",
         "psalm/plugin-mockery": "^0.3",


### PR DESCRIPTION
Sylius do not allow PHP 8 install, I will create an issue to allow PHP 8 installs on a dev branch in order to allow OSS to adopt it

```
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - sylius/sylius[v1.8.0, ..., v1.9.2] require php ^7.3 -> your php version (8.0.3) does not satisfy that requirement.
    - Root composer.json requires sylius/sylius ^1.8 -> satisfiable by sylius/sylius[v1.8.0, ..., v1.9.2].
```