### PR TITLE
Add files in fixture utility system

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,41 @@ In front :
 
 ![The GMap display](screenshots/gmap_render.png)
 
+## File in fixtures management
+
+In some cases you will want to add UI elements to your content fixtures which are Rich Editor fields. If you need files in your UI elements, you can use a dedicated fixture. It is used as follows.   
+
+```yaml
+sylius_fixtures:
+    suites:
+        my_project:
+            fixtures:
+                my_files:
+                    name: monsieurbiz_rich_editor_file
+                    options:
+                        files:
+                            -   source_path: 'src/Resources/fixtures/bar1.png'
+                                target_path: 'image/foo/bar1.png'
+                            -   source_path: 'src/Resources/fixtures/file.pdf'
+                                target_path: 'baz/file.pdf'
+```
+
+The exemple below will copy files to `public/media/image/foo/bar1.png` and `public/media/foo/file.pdf`.
+
+Now you can use files in your content fixtures:
+
+```yaml
+description: |
+    [{
+        "code": "app.my_ui_element",
+        "data": {
+          "title": "My title",
+          "image": "/media/image/foo/bar1.png",
+          "file": "/media/baz/file.pdf"
+        }
+    }]
+```
+
 ## Contributing
 
 You can open an issue or a Pull Request if you want! 😘  

--- a/src/Fixture/FileFixture.php
+++ b/src/Fixture/FileFixture.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Rich Editor plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusRichEditorPlugin\Fixture;
+
+use MonsieurBiz\SyliusRichEditorPlugin\Uploader\FixtureFileUploaderInterface;
+use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
+use Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+final class FileFixture extends AbstractFixture implements FixtureInterface
+{
+    /**
+     * @var FixtureFileUploaderInterface
+     */
+    private FixtureFileUploaderInterface $uploader;
+
+    /**
+     * @param FixtureFileUploaderInterface $uploader
+     */
+    public function __construct(FixtureFileUploaderInterface $uploader)
+    {
+        $this->uploader = $uploader;
+    }
+
+    /**
+     * @param array $options
+     */
+    public function load(array $options): void
+    {
+        foreach ($options['files'] as $data) {
+            $file = new UploadedFile($data['source_path'], basename($data['source_path']));
+            $this->uploader->upload($file, $data['target_path']);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'monsieurbiz_rich_editor_file';
+    }
+
+    /**
+     * @param ArrayNodeDefinition $optionsNode
+     */
+    protected function configureOptionsNode(ArrayNodeDefinition $optionsNode): void
+    {
+        /** @phpstan-ignore-next-line */
+        $optionsNode
+            ->children()
+                ->arrayNode('files')
+                    ->arrayPrototype()
+                        ->children()
+                            ->scalarNode('source_path')->cannotBeEmpty()->end()
+                            ->scalarNode('target_path')->cannotBeEmpty()->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+}

--- a/src/Resources/config/config.yaml
+++ b/src/Resources/config/config.yaml
@@ -2,3 +2,13 @@ imports:
     - { resource: "services.yaml" }
     - { resource: "sylius/ui.yaml" }
     - { resource: "richeditor.yaml" }
+
+knp_gaufrette:
+    adapters:
+        monsieurbiz_rich_editor_fixture_file:
+            local:
+                directory: '%sylius_core.public_dir%/media'
+                create: true
+    filesystems:
+        monsieurbiz_rich_editor_fixture_file:
+            adapter: 'monsieurbiz_rich_editor_fixture_file'

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -7,13 +7,20 @@ services:
         bind:
             string $monsieurbizRicheditorDefaultElement: '%monsieurbiz.richeditor.config.default_element%'
             string $monsieurbizRicheditorDefaultElementDataField: '%monsieurbiz.richeditor.config.default_element_data_field%'
+            Gaufrette\FilesystemInterface $filesystem: '@gaufrette.monsieurbiz_rich_editor_fixture_file_filesystem'
 
     MonsieurBiz\SyliusRichEditorPlugin\Controller\:
         resource: '../../Controller'
         tags: ['controller.service_arguments']
+        
+    MonsieurBiz\SyliusRichEditorPlugin\Fixture\:
+        resource: '../../Fixture'
 
     MonsieurBiz\SyliusRichEditorPlugin\Twig\:
         resource: '../../Twig'
+
+    MonsieurBiz\SyliusRichEditorPlugin\Uploader\:
+        resource: '../../Uploader'
 
     monsieurbiz.richeditor.metadata_registry:
         class: MonsieurBiz\SyliusRichEditorPlugin\UiElement\Metadata\Registry

--- a/src/Uploader/FixtureFileUploaderInterface.php
+++ b/src/Uploader/FixtureFileUploaderInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Rich Editor plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusRichEditorPlugin\Uploader;
+
+use Symfony\Component\HttpFoundation\File\File;
+
+interface FixtureFileUploaderInterface
+{
+    /**
+     * @param File $file
+     * @param string $target
+     */
+    public function upload(File $file, string $target): void;
+}

--- a/src/Uploader/FixtureFixtureFileUploader.php
+++ b/src/Uploader/FixtureFixtureFileUploader.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Rich Editor plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusRichEditorPlugin\Uploader;
+
+use Gaufrette\FilesystemInterface;
+use Symfony\Component\HttpFoundation\File\File;
+use Webmozart\Assert\Assert;
+
+final class FixtureFixtureFileUploader implements FixtureFileUploaderInterface
+{
+    /**
+     * @var FilesystemInterface
+     */
+    private FilesystemInterface $filesystem;
+
+    /**
+     * @param FilesystemInterface $filesystem
+     */
+    public function __construct(FilesystemInterface $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * @param File $file
+     * @param string $target
+     */
+    public function upload(File $file, string $target): void
+    {
+        Assert::isInstanceOf($file, File::class);
+
+        if ($this->filesystem->has($target)) {
+            $this->remove($target);
+        }
+
+        $this->filesystem->write(
+            $target,
+            (string) file_get_contents($file->getPathname())
+        );
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return bool
+     */
+    public function remove(string $path): bool
+    {
+        if ($this->filesystem->has($path)) {
+            return $this->filesystem->delete($path);
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## File in fixtures management

In some cases you will want to add UI elements to your content fixtures which are Rich Editor fields. If you need files in your UI elements, you can use a dedicated fixture. It is used as follows.   

```yaml
sylius_fixtures:
    suites:
        my_project:
            fixtures:
                my_files:
                    name: monsieurbiz_rich_editor_file
                    options:
                        files:
                            -   source_path: 'src/Resources/fixtures/bar1.png'
                                target_path: 'image/foo/bar1.png'
                            -   source_path: 'src/Resources/fixtures/file.pdf'
                                target_path: 'baz/file.pdf'
```

The exemple below will copy files to `public/media/image/foo/bar1.png` and `public/media/foo/file.pdf`.

Now you can use files in your content fixtures:

```yaml
description: |
    [{
        "code": "app.my_ui_element",
        "data": {
          "title": "My title",
          "image": "/media/image/foo/bar1.png",
          "file": "/media/baz/file.pdf"
        }
    }]
```
