### PR TITLE
Allow creation of image / image_collection in fixture without link attribute

### DIFF
--- a/src/Resources/views/Admin/UiElement/image.html.twig
+++ b/src/Resources/views/Admin/UiElement/image.html.twig
@@ -11,7 +11,7 @@
 {% if element.image is defined %}
 {% set align = element.align is defined and element.align is not empty ? element.align : 'inherit' %}
 <p style="text-align: {{align}};">
-    {% if element.link is not empty %}
+    {% if element.link|default('') is not empty %}
         <a href="{{ element.link }}">
             <img class="ui fluid image" src="{{ element.image }}" alt="{{ element.alt|default('') }}" title="{{ element.title|default('') }}" />
         </a>

--- a/src/Resources/views/Admin/UiElement/image_collection.html.twig
+++ b/src/Resources/views/Admin/UiElement/image_collection.html.twig
@@ -7,7 +7,7 @@
 <div class="ui stackable two column grid">
     {% for image in element.images %}
         <div class="column">
-            {% if image.link is not empty %}
+            {% if image.link|default('') is not empty %}
                 <a href="{{ image.link }}">
                     <img class="ui fluid image" src="{{ image.image }}" alt="{{ image.alt|default('') }}" title="{{ image.title|default('') }}" />
                 </a>

--- a/src/Resources/views/Shop/UiElement/image.html.twig
+++ b/src/Resources/views/Shop/UiElement/image.html.twig
@@ -11,7 +11,7 @@
 {% if element.image is defined %}
 {% set align = element.align is defined and element.align is not empty ? element.align : 'inherit' %}
 <p style="text-align: {{align}};">
-    {% if element.link is not empty %}
+    {% if element.link|default('') is not empty %}
         <a href="{{ element.link }}">
             <img class="ui fluid image" src="{{ element.image }}" alt="{{ element.alt|default('') }}" title="{{ element.title|default('') }}" />
         </a>

--- a/src/Resources/views/Shop/UiElement/image_collection.html.twig
+++ b/src/Resources/views/Shop/UiElement/image_collection.html.twig
@@ -7,7 +7,7 @@
 <div class="ui stackable two column grid">
     {% for image in element.images %}
         <div class="column">
-            {% if image.link is not empty %}
+            {% if image.link|default('') is not empty %}
                 <a href="{{ image.link }}">
                     <img class="ui fluid image" src="{{ image.image }}" alt="{{ image.alt|default('') }}" title="{{ image.title|default('') }}" />
                 </a>


### PR DESCRIPTION
The original files did not allow adding an image / image_collection in fixtures without adding the "link" attribute