### PR TITLE
Keep the possibility to have a type in the first place

### DIFF
--- a/src/Controller/FormController.php
+++ b/src/Controller/FormController.php
@@ -104,7 +104,13 @@ class FormController extends AbstractController
             $result[$uiElementIndex] = '';
 
             if (!isset($uiElementData['code'])) {
-                continue;
+                if (isset($uiElementData['type'], $uiElementData['fields'])) {
+                    $uiElementData['code'] = $uiElementData['type'];
+                    $uiElementData['data'] = $uiElementData['fields']; // @phpstan-ignore-line
+                    unset($uiElementData['type'], $uiElementData['fields']); // @phpstan-ignore-line
+                } else {
+                    continue;
+                }
             }
 
             try {


### PR DESCRIPTION
It happens when the call is made with old data.
