### PR TITLE
Avoid error on save empty Youtube URL

### DIFF
--- a/src/Validator/Constraints/YoutubeUrlValidator.php
+++ b/src/Validator/Constraints/YoutubeUrlValidator.php
@@ -29,7 +29,7 @@ class YoutubeUrlValidator extends ConstraintValidator
 
         if (!preg_match(self::YOUTUBE_REGEX_VALIDATOR, (string) $value)) {
             $this->context->buildViolation($constraint->message)
-                ->setParameter('{{ string }}', $value)
+                ->setParameter('{{ string }}', (string) $value)
                 ->addViolation()
             ;
         }


### PR DESCRIPTION
Avoid 500 when saving empty Youtube URL 

```
Symfony\Component\Validator\Violation\ConstraintViolationBuilder::setParameter(): Argument #2 ($value) must be of type string, null given, called in /Users/mhuran/Sites/SyliusRichEditor/apps/sylius/vendor/monsieurbiz/sylius-rich-editor-plugin/src/Validator/Constraints/YoutubeUrlValidator.php on line 32
```