### PR TITLE
Gives the possibility to define specific constraints on images or videos

### DIFF
--- a/src/Form/Constraints/RichEditorConstraints.php
+++ b/src/Form/Constraints/RichEditorConstraints.php
@@ -21,37 +21,37 @@ final class RichEditorConstraints
      * Return constraint depending on data
      * If user created the element, the field is required
      * If it's an edition and it contains a filename, we don't flag it as required.
-     *
-     * @return array
      */
-    public static function getImageConstraints(array $data, string $fieldName, bool $required = true)
+    public static function getImageConstraints(array $data, string $fieldName, bool $required = true, array $defaultConstraints = []): array
     {
-        // No constraint if current value is a string with the filepath
-        if (isset($data[$fieldName]) && \is_string($data[$fieldName])) {
-            return [];
-        }
-
-        if (!$required) {
-            return [
+        if (empty($defaultConstraints)) {
+            $defaultConstraints = [
                 new Assert\Image([]),
             ];
         }
 
-        // No image set yet, we require file
-        return [
-            new Assert\NotBlank([]),
-            new Assert\Image([]),
-        ];
+        return self::getFileConstraints($data, $fieldName, $required, $defaultConstraints);
     }
 
     /**
      * Return constraint depending on data
      * If user created the element, the field is required
      * If it's an edition and it contains a filename, we don't flag it as required.
-     *
-     * @return array
      */
-    public static function getVideoConstraints(array $data, string $fieldName, bool $required = true)
+    public static function getVideoConstraints(array $data, string $fieldName, bool $required = true, array $defaultConstraints = []): array
+    {
+        if (empty($defaultConstraints)) {
+            $defaultConstraints = [
+                new Assert\File([
+                    'mimeTypes' => ['video/mpeg', 'video/mp4', 'video/quicktime', 'video/x-ms-wmv', 'video/x-msvideo', 'video/x-flv'],
+                ]),
+            ];
+        }
+
+        return self::getFileConstraints($data, $fieldName, $required, $defaultConstraints);
+    }
+
+    private static function getFileConstraints(array $data, string $fieldName, bool $required, array $constraints): array
     {
         // No constraint if current value is a string with the filepath
         if (isset($data[$fieldName]) && \is_string($data[$fieldName])) {
@@ -59,19 +59,12 @@ final class RichEditorConstraints
         }
 
         if (!$required) {
-            return [
-                new Assert\File([
-                    'mimeTypes' => ['video/mpeg', 'video/mp4', 'video/quicktime', 'video/x-ms-wmv', 'video/x-msvideo', 'video/x-flv'],
-                ]),
-            ];
+            return $constraints;
         }
 
-        // No video set yet, we require file
-        return [
-            new Assert\NotBlank([]),
-            new Assert\File([
-                'mimeTypes' => ['video/mpeg', 'video/mp4', 'video/quicktime', 'video/x-ms-wmv', 'video/x-msvideo', 'video/x-flv'],
-            ]),
-        ];
+        // No file set yet, we require file
+        $constraints[] = new Assert\NotBlank([]);
+
+        return $constraints;
     }
 }


### PR DESCRIPTION
For example, I want to define a custom maxSize in the Image constraint:

```php
->add('image', ImageType::class, [
    'label' => 'app.form.image',
    'constraints' => [
        new Assert\Image(['maxSize' => '2M']),
    ],
])
```

And add the event listener with this code:

```php
$options['constraints'] = RichEditorConstraints::getImageConstraints(
    $data,
    'image',
    $options['required'] ?? true,
    $options['constraints'] ?? []
);
```