### PR TITLE
Fix array keys of an element type collection

### DIFF
--- a/src/Controller/FormController.php
+++ b/src/Controller/FormController.php
@@ -19,6 +19,7 @@ use MonsieurBiz\SyliusRichEditorPlugin\UiElement\UiElementFormOptionsInterface;
 use MonsieurBiz\SyliusRichEditorPlugin\UiElement\UiElementInterface;
 use MonsieurBiz\SyliusRichEditorPlugin\Uploader\FileUploaderInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\FileType as NativeFileType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -193,6 +194,10 @@ class FormController extends AbstractController
         $processedData = [];
         foreach ($form as $child) {
             $formData = $this->processFormData($child, $fileUploader, $requestData[$child->getName()] ?? []);
+            $formType = $child->getConfig()->getType()->getInnerType();
+            if ($formType instanceof CollectionType) {
+                $formData = array_values($formData);
+            }
             $processedData[$child->getName()] = $formData;
         }
 


### PR DESCRIPTION
When you get an element with form type CollectionType and you create 3 items, you'll get the following indices `[0 => data, 1 => data, 2 => data]`
If you remove the index 1 then you get the following indices `[0 => data, 2 => data]`
When you save the page, all elements are saved into json object but the format of this sub element is converted into object instead of array.
To fix that you need to apply `array_values()` to reset keys. This function cannot be applied on a Form Event because you override form data with the request into this method `processFormDataWithoutChild`  due to this:
```
if ($form->getConfig()->getType()->getInnerType() instanceof NativeFileType && !empty($requestData)) {
    // Check if we have a string value for this fields which is the file path (During edition for example)
    return $requestData; // Will return the current filename string
}
```