### PR TITLE
Allow UI Elements to be declared using PHP attributes

### DIFF
--- a/.github/workflows/recipe.yaml
+++ b/.github/workflows/recipe.yaml
@@ -18,21 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1']
-        sylius: ['~1.8.0', '~1.9.0', '~1.10.0', '~1.11.0', '~1.12.0']
-        exclude:
-          - php: 8.0
-            sylius: '~1.8.0'
-          - php: 8.0
-            sylius: '~1.9.0'
-          - php: 8.1
-            sylius: '~1.8.0'
-          - php: 8.1
-            sylius: '~1.9.0'
-          - php: 7.4
-            sylius: '~1.11.0'
-          - php: 7.4
-            sylius: '~1.12.0'
+        php: ['8.0', '8.1']
+        sylius: ['~1.10.0', '~1.11.0', '~1.12.0']
 
     steps:
       - name: Setup PHP

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['8.0', '8.1']
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -217,6 +217,20 @@ You can distinguish the `Row` element and the `Column` element by their dotted b
 
 In this example, we will add a Google Maps element.
 
+With the Maker Bundle, you can create a new UiElement very easily: 
+
+```bash
+bin/console make:ui-element
+```
+
+Then you will have to answer some questions, or you can add arguments to the command to avoid the questions.
+
+```bash
+bin/console make:ui-element app.google_maps "map pin"
+```
+
+Just add the translations!
+
 ### Define your UiElement (for PHP < 8.1)
 
 **Tips:** If you are using PHP 8.1 or newer, you can use the `#[AsUiElement]` attribute to define your UiElement. You can skip this step.

--- a/README.md
+++ b/README.md
@@ -217,7 +217,9 @@ You can distinguish the `Row` element and the `Column` element by their dotted b
 
 In this example, we will add a Google Maps element.
 
-### Define your UiElement
+### Define your UiElement (for PHP < 8.1)
+
+**Tips:** If you are using PHP 8.1 or newer, you can use the `#[AsUiElement]` attribute to define your UiElement. You can skip this step.
 
 Define your UiElement in your configuration folder, let's say in `config/packages/monsieurbiz_sylius_richeditor_plugin.yaml` as example.
 
@@ -271,6 +273,48 @@ class GoogleMapsType extends AbstractType
         ;
     }
 }
+```
+
+For PHP 8.1 and newer, you can use the `#[AsUiElement]` attribute to define your UiElement. For example:
+
+```php
+<?php
+
+// ...
+
+use MonsieurBiz\SyliusRichEditorPlugin\Attribute\AsUiElement;
+
+#[AsUiElement(
+    code: 'app.google_maps',
+    icon: 'map pin',
+)]
+class GoogleMapsType extends AbstractType
+// ...
+```
+
+The title, description and templates values are generated automatically from the code. In this example :
+
+- the title will be `app.ui_element.google_maps.title`,
+- the description will be `app.ui_element.google_maps.description`,
+- the admin template will be `/Admin/UiElement/google_maps.html.twig`, 
+- and the front template will be `/Shop/UiElement/google_maps.html.twig`.
+
+But you can override them if you want:
+
+```php
+#[AsUiElement(
+    code: 'app.google_maps',
+    title: 'my_cusom.title', // Use your own translation key or a string
+    description: 'my_custom.description',
+    icon: 'map pin',
+    templates: new TemplatesUiElement(
+        adminRender: 'MyCusomPath/google_maps.html.twig',
+        frontRender: 'MyCusomPath/google_maps.html.twig',
+    ),
+    uiElement: GoogleMapsUiElement::class, // Use your own UiElement class
+    tags: ['map'], // Add some tags to filter the UiElement
+    wireframe: 'google_maps', // Add a wireframe to help the user to understand the UiElement, see below
+)]
 ```
 
 ### Add your translations of course

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "symfony/dotenv": "^4.4",
         "symfony/flex": "^1.7",
         "symfony/web-profiler-bundle": "^4.4",
-        "phpmd/phpmd": "@stable"
+        "phpmd/phpmd": "@stable",
+        "symfony/maker-bundle": "^1.39"
     },
     "prefer-stable": true,
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
     "description": "A Rich Editor plugin for Sylius.",
     "license": "MIT",
     "require": {
-        "php": "~7.4|~8.0|~8.1",
+        "php": "^8.0",
         "ext-json": "*",
         "ext-intl": "*",
-        "sylius/sylius": ">=1.8 <1.13"
+        "sylius/sylius": ">=1.10 <1.13"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",

--- a/dist/config/packages/monsieurbiz_sylius_rich_editor_plugin_custom.yaml
+++ b/dist/config/packages/monsieurbiz_sylius_rich_editor_plugin_custom.yaml
@@ -4,17 +4,18 @@ monsieurbiz_sylius_richeditor:
             tags: [ html ]
         monsieurbiz.youtube:
             tags: [ youtube ]
-        app.google_maps:
-            title: 'app.ui_element.google_maps.title'
-            description: 'app.ui_element.google_maps.description'
-            icon: map pin
-            tags: [ map ]
-            classes:
-                form: App\Form\Type\UiElement\GoogleMapsType
-                ui_element: App\UiElement\GoogleMapsUiElement
-            templates:
-                admin_render: '/Admin/UiElement/google_maps.html.twig'
-                front_render: '/Shop/UiElement/google_maps.html.twig'
+#        Example without PHP Attributes or for PHP version < 8.1
+#        app.google_maps:
+#            title: 'app.ui_element.google_maps.title'
+#            description: 'app.ui_element.google_maps.description'
+#            icon: map pin
+#            tags: [ map ]
+#            classes:
+#                form: App\Form\Type\UiElement\GoogleMapsType
+#                ui_element: App\UiElement\GoogleMapsUiElement
+#            templates:
+#                admin_render: '/Admin/UiElement/google_maps.html.twig'
+#                front_render: '/Shop/UiElement/google_maps.html.twig'
         app.noseeme:
             title: 'You should not see me'
             description: 'The invisible Ui Element'

--- a/dist/src/Form/Type/UiElement/GoogleMapsType.php
+++ b/dist/src/Form/Type/UiElement/GoogleMapsType.php
@@ -13,11 +13,19 @@ declare(strict_types=1);
 
 namespace App\Form\Type\UiElement;
 
+use App\UiElement\GoogleMapsUiElement;
+use MonsieurBiz\SyliusRichEditorPlugin\Attribute\AsUiElement;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
+#[AsUiElement(
+    code: 'app.google_maps',
+    icon: 'map pin',
+    uiElement: GoogleMapsUiElement::class,
+    tags: ['map'],
+)]
 class GoogleMapsType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/dist/templates/Admin/UiElement/google_maps.html.twig
+++ b/dist/templates/Admin/UiElement/google_maps.html.twig
@@ -1,0 +1,13 @@
+{#
+UI Element template
+type: google_map
+element fields:
+    link: string
+element methods:
+    getLocale(): string
+#}
+
+<div style="width: 100%">
+    {{ ui_element.getLocale() }}
+    {{ element.link|replace({'hl=en': 'hl=' ~ ui_element.getLocale()}) }}
+</div>

--- a/dist/templates/Shop/UiElement/google_maps.html.twig
+++ b/dist/templates/Shop/UiElement/google_maps.html.twig
@@ -1,0 +1,12 @@
+{#
+UI Element template
+type: google_map
+element fields:
+    link: string
+element methods:
+    getLocale(): string
+#}
+
+<div style="width: 100%">
+    <iframe width="100%" height="600" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="{{ element.link }}"><a href="https://www.gps.ie/">gps devices</a></iframe>
+</div>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -44,7 +44,7 @@
     <rule ref="rulesets/naming.xml/ShortClassName"/>
     <rule ref="rulesets/naming.xml/ShortVariable">
         <properties>
-            <property name="exceptions" value="id,em"/>
+            <property name="exceptions" value="id,em,io"/>
         </properties>
     </rule>
     <rule ref="rulesets/naming.xml/ShortMethodName"/>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,5 +19,8 @@ parameters:
         - 'tests/Application/app/**.php'
         - 'tests/Application/src/**.php'
 
+        # Skeleton files
+        - 'src/Resources/skeleton/*.php'
+
     ignoreErrors:
         - '/Parameter #1 \$configuration of method Symfony\\Component\\DependencyInjection\\Extension\\Extension::processConfiguration\(\) expects Symfony\\Component\\Config\\Definition\\ConfigurationInterface, Symfony\\Component\\Config\\Definition\\ConfigurationInterface\|null given\./'

--- a/src/Attribute/AsUiElement.php
+++ b/src/Attribute/AsUiElement.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Rich Editor plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusRichEditorPlugin\Attribute;
+
+use Attribute;
+use MonsieurBiz\SyliusRichEditorPlugin\UiElement\UiElement;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class AsUiElement
+{
+    /**
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     */
+    public function __construct(
+        public string $code,
+        public string $icon,
+        public ?string $title = null,
+        public ?string $description = null,
+        public string $uiElement = UiElement::class,
+        public ?TemplatesUiElement $templates = null,
+        public string $alias = '',
+        public string $wireframe = '',
+        public bool $enabled = true,
+        public array $tags = [],
+    ) {
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function getConfiguration(): array
+    {
+        $configuration = [
+            'title' => $this->getTitle(),
+            'description' => $this->getDescription(),
+            'icon' => $this->icon,
+            'wireframe' => $this->wireframe,
+            'enabled' => $this->enabled,
+            'tags' => $this->tags,
+            'classes' => [
+                'ui_element' => $this->uiElement,
+            ],
+            'templates' => [
+                'admin_render' => $this->getTemplates()->adminRender,
+                'front_render' => $this->getTemplates()->frontRender,
+                'admin_form' => $this->getTemplates()->adminForm,
+            ],
+        ];
+
+        if ($this->alias) {
+            $configuration['alias'] = $this->alias;
+        }
+
+        return $configuration;
+    }
+
+    private function getTitle(): string
+    {
+        return $this->title ?? 'app.ui_element.' . $this->getLastPartOfCode() . '.title';
+    }
+
+    private function getDescription(): string
+    {
+        return $this->description ?? 'app.ui_element.' . $this->getLastPartOfCode() . '.description';
+    }
+
+    private function getTemplates(): TemplatesUiElement
+    {
+        return $this->templates ?? new TemplatesUiElement(
+            adminRender: 'Admin/UiElement/' . $this->getLastPartOfCode() . '.html.twig',
+            frontRender: 'Shop/UiElement/' . $this->getLastPartOfCode() . '.html.twig',
+        );
+    }
+
+    private function getLastPartOfCode(): string
+    {
+        $parts = explode('.', $this->code);
+
+        return end($parts);
+    }
+}

--- a/src/Attribute/AsUiElement.php
+++ b/src/Attribute/AsUiElement.php
@@ -59,6 +59,7 @@ class AsUiElement
                 'front_render' => $this->getTemplates()->frontRender,
                 'admin_form' => $this->getTemplates()->adminForm,
             ],
+            'form_options' => [],
         ];
 
         if ($this->alias) {

--- a/src/Attribute/TemplatesUiElement.php
+++ b/src/Attribute/TemplatesUiElement.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Rich Editor plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusRichEditorPlugin\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class TemplatesUiElement
+{
+    public function __construct(
+        public string $adminRender,
+        public string $frontRender,
+        public string $adminForm = '@MonsieurBizSyliusRichEditorPlugin/Admin/form.html.twig',
+    ) {
+    }
+}

--- a/src/DependencyInjection/UiElementRegistryPass.php
+++ b/src/DependencyInjection/UiElementRegistryPass.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace MonsieurBiz\SyliusRichEditorPlugin\DependencyInjection;
 
+use MonsieurBiz\SyliusRichEditorPlugin\Attribute\AsUiElement;
 use MonsieurBiz\SyliusRichEditorPlugin\UiElement\Metadata;
 use MonsieurBiz\SyliusRichEditorPlugin\UiElement\UiElement;
 use MonsieurBiz\SyliusRichEditorPlugin\UiElement\UiElementInterface;
+use ReflectionClass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -38,35 +40,79 @@ final class UiElementRegistryPass implements CompilerPassInterface
             return;
         }
 
+        $this->processConfiguration($uiElements, $container, $registry, $metadataRegistry);
+        $this->processAttribute($container, $registry, $metadataRegistry);
+    }
+
+    private function processConfiguration(mixed $uiElements, ContainerBuilder $container, Definition $registry, Definition $metadataRegistry): void
+    {
         if (!\is_array($uiElements)) {
             return;
         }
 
         foreach ($uiElements as $code => $configuration) {
-            $metadataRegistry->addMethodCall('addFromCodeAndConfiguration', [$code, $configuration]);
-            $metadata = Metadata::fromCodeAndConfiguration($code, $configuration);
-
-            $id = $metadata->getServiceId('richeditor.ui_element');
-
-            $class = $metadata->getClass('ui_element');
-            $this->validateUiElementResource($class);
-
-            $uiElementDefinition = $container->setDefinition($id, (new Definition($class))->setAutowired(true));
-            $uiElementDefinition->addMethodCall('setMetadata', [$this->getMetadataDefinition($metadata)]);
-            $uiElementDefinition->addMethodCall('setTranslator', [new Reference('translator')]);
-            $uiElementDefinition->addMethodCall('setTwigEnvironment', [new Reference('Twig\Environment')]);
-
-            $aliases = [
-                UiElementInterface::class . ' $' . $metadata->getCamelCasedCode() . 'UiElement' => $id,
-                UiElement::class . ' $' . $metadata->getCamelCasedCode() . 'UiElement' => $id,
-            ];
-            if (UiElement::class !== $class) {
-                $aliases[$class . ' $' . $metadata->getCamelCasedCode() . 'UiElement'] = $id;
+            if (!\is_array($configuration)) {
+                continue;
             }
-            $container->addAliases($aliases);
-
-            $registry->addMethodCall('addUiElement', [new Reference($id)]);
+            $this->registerUiElement($code, $configuration, $container, $registry, $metadataRegistry);
         }
+    }
+
+    private function processAttribute(ContainerBuilder $container, Definition $registry, Definition $metadataRegistry): void
+    {
+        foreach ($container->getDefinitions() as $definition) {
+            if ($this->accept($definition) && $reflectionClass = $container->getReflectionClass($definition->getClass(), false)) {
+                $this->processClass($definition, $reflectionClass, $container, $registry, $metadataRegistry);
+            }
+        }
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflectionClass
+     */
+    private function processClass(Definition $definition, ReflectionClass $reflectionClass, ContainerBuilder $container, Definition $registry, Definition $metadataRegistry): void
+    {
+        foreach ($reflectionClass->getAttributes(AsUiElement::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+            $attribute = $attribute->newInstance();
+            /** @var AsUiElement $attribute */
+            $code = $attribute->getCode();
+            $configuration = $attribute->getConfiguration();
+            $configuration['classes']['form'] = $definition->getClass(); // Add the form class to the configuration
+
+            $this->registerUiElement($code, $configuration, $container, $registry, $metadataRegistry);
+        }
+    }
+
+    private function accept(Definition $definition): bool
+    {
+        return !$definition->isAbstract();
+    }
+
+    private function registerUiElement(string $code, array $configuration, ContainerBuilder $container, Definition $registry, Definition $metadataRegistry): void
+    {
+        $metadataRegistry->addMethodCall('addFromCodeAndConfiguration', [$code, $configuration]);
+        $metadata = Metadata::fromCodeAndConfiguration($code, $configuration);
+
+        $id = $metadata->getServiceId('richeditor.ui_element');
+
+        $class = $metadata->getClass('ui_element');
+        $this->validateUiElementResource($class);
+
+        $uiElementDefinition = $container->setDefinition($id, (new Definition($class))->setAutowired(true));
+        $uiElementDefinition->addMethodCall('setMetadata', [$this->getMetadataDefinition($metadata)]);
+        $uiElementDefinition->addMethodCall('setTranslator', [new Reference('translator')]);
+        $uiElementDefinition->addMethodCall('setTwigEnvironment', [new Reference('Twig\Environment')]);
+
+        $aliases = [
+            UiElementInterface::class . ' $' . $metadata->getCamelCasedCode() . 'UiElement' => $id,
+            UiElement::class . ' $' . $metadata->getCamelCasedCode() . 'UiElement' => $id,
+        ];
+        if (UiElement::class !== $class) {
+            $aliases[$class . ' $' . $metadata->getCamelCasedCode() . 'UiElement'] = $id;
+        }
+        $container->addAliases($aliases);
+
+        $registry->addMethodCall('addUiElement', [new Reference($id)]);
     }
 
     /**

--- a/src/Maker/UiElementMaker.php
+++ b/src/Maker/UiElementMaker.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Rich Editor plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusRichEditorPlugin\Maker;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
+use Symfony\Bundle\MakerBundle\Str;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Form\AbstractType;
+use Webmozart\Assert\Assert;
+
+final class UiElementMaker extends AbstractMaker
+{
+    public static function getCommandName(): string
+    {
+        return 'make:ui-element';
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function configureCommand(Command $command, InputConfiguration $inputConfig): void
+    {
+        $command
+            ->addArgument('code', InputArgument::OPTIONAL, 'The code of the UI Element (e.g. <fg=yellow>my_ui_element</>)')
+            ->addArgument('icon', InputArgument::OPTIONAL, 'The semantic icon code for the UI Element (e.g. <fg=yellow>map pin</>)')
+            ->addArgument('code_prefix', InputArgument::OPTIONAL, 'The code prefix for the UI Element (e.g. <fg=yellow>app</>)', 'app')
+            ->setDescription('Creates a new UI Element FormType and templates')
+        ;
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
+    {
+        $code = $input->getArgument('code');
+        $codePrefix = $input->getArgument('code_prefix');
+        Assert::string($code);
+        $name = Str::asCamelCase($code);
+        $uiElementFormClassNameDetails = $generator->createClassNameDetails(
+            $name,
+            'Form\\Type\\UiElement\\',
+            'Type'
+        );
+        $generator->generateClass(
+            $uiElementFormClassNameDetails->getFullName(),
+            __DIR__ . '/../Resources/skeleton/UiElementFormType.tpl.php',
+            [
+                'code' => sprintf('%s.%s', $codePrefix, $code),
+                'icon' => 'map pin',
+                'tags' => json_encode([]),
+            ]
+        );
+
+        // Generate templates
+        $generator->generateTemplate(
+            sprintf('Admin/UiElement/%s.html.twig', $code),
+            __DIR__ . '/../Resources/skeleton/UiElementTemplate.tpl.php',
+            [
+                'code' => $code,
+            ]
+        );
+        $generator->generateTemplate(
+            sprintf('Shop/UiElement/%s.html.twig', $code),
+            __DIR__ . '/../Resources/skeleton/UiElementTemplate.tpl.php',
+            [
+                'code' => $code,
+            ]
+        );
+
+        $generator->writeChanges();
+
+        $this->writeSuccessMessage($io);
+        $io->text([
+            'Next: Open your new UI Element FormType and templates, and start customizing it.',
+        ]);
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies): void
+    {
+        $dependencies->addClassDependency(
+            AbstractType::class,
+            'monsieurbiz/sylius-rich-editor-plugin'
+        );
+    }
+}

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -3,7 +3,7 @@ services:
         autowire: true
         autoconfigure: true
         public: false
-        
+
         bind:
             string $monsieurbizRicheditorDefaultElement: '%monsieurbiz.richeditor.config.default_element%'
             string $monsieurbizRicheditorDefaultElementDataField: '%monsieurbiz.richeditor.config.default_element_data_field%'
@@ -12,7 +12,7 @@ services:
     MonsieurBiz\SyliusRichEditorPlugin\Controller\:
         resource: '../../Controller'
         tags: ['controller.service_arguments']
-    
+
     MonsieurBiz\SyliusRichEditorPlugin\Fixture\:
         resource: '../../Fixture'
 
@@ -21,7 +21,7 @@ services:
 
     MonsieurBiz\SyliusRichEditorPlugin\Uploader\:
         resource: '../../Uploader'
-    
+
     MonsieurBiz\SyliusRichEditorPlugin\Switcher\:
         resource: '../../Switcher'
 
@@ -45,3 +45,7 @@ services:
     MonsieurBiz\SyliusRichEditorPlugin\Uploader\FileUploaderInterface: '@MonsieurBiz\SyliusRichEditorPlugin\Uploader\FileUploader'
 
     MonsieurBiz\SyliusRichEditorPlugin\Switcher\SwitchAdminLocaleInterface: '@MonsieurBiz\SyliusRichEditorPlugin\Switcher\SwitchAdminLocale'
+
+    # Maker
+    MonsieurBiz\SyliusRichEditorPlugin\Maker\UiElementMaker:
+        tags: ['maker.command']

--- a/src/Resources/skeleton/UiElementFormType.tpl.php
+++ b/src/Resources/skeleton/UiElementFormType.tpl.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+echo "<?php\n"; ?>
+declare(strict_types=1);
+
+namespace <?php echo $namespace; ?>;
+
+use MonsieurBiz\SyliusRichEditorPlugin\Attribute\AsUiElement;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+#[AsUiElement(
+    code: '<?php echo $code; ?>',
+    icon: '<?php echo $icon; ?>',
+    tags: <?php echo $tags; ?>,
+)]
+class <?php echo $class_name; ?> extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        // Build your form here
+    }
+}

--- a/src/Resources/skeleton/UiElementTemplate.tpl.php
+++ b/src/Resources/skeleton/UiElementTemplate.tpl.php
@@ -1,0 +1,6 @@
+{#
+UI Element template
+type: <?php echo $code . "\n"; ?>
+element fields:
+    - …
+#}

--- a/src/UiElement/UiElementFormOptionsTrait.php
+++ b/src/UiElement/UiElementFormOptionsTrait.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace MonsieurBiz\SyliusRichEditorPlugin\UiElement;
 
+use InvalidArgumentException;
+
 trait UiElementFormOptionsTrait
 {
     use UiElementTrait;
@@ -22,6 +24,10 @@ trait UiElementFormOptionsTrait
      */
     public function getFormOptions(): array
     {
-        return $this->metadata->getParameter('form_options');
+        try {
+            return $this->metadata->getParameter('form_options');
+        } catch (InvalidArgumentException) {
+            return [];
+        }
     }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -701,6 +701,9 @@
     "sylius-labs/polyfill-symfony-security": {
         "version": "v1.0.0"
     },
+    "sylius/calendar": {
+        "version": "v0.3.0"
+    },
     "sylius/fixtures-bundle": {
         "version": "v1.6.1"
     },
@@ -850,6 +853,15 @@
     },
     "symfony/intl": {
         "version": "v4.4.13"
+    },
+    "symfony/maker-bundle": {
+        "version": "1.39",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "fadbfe33303a76e25cb63401050439aa9b1a9c7f"
+        }
     },
     "symfony/messenger": {
         "version": "4.3",


### PR DESCRIPTION
FYI, CI is fixed in #218 

In this PR, we add PHP attributes to be able to declare UI Elements directly from the FormType.

I'm also removing support for PHP version 7.4 and Sylius 1.8 and 1.9. Go to the future 🚀

In [the form type section of the README](https://github.com/delyriand/SyliusRichEditorPlugin/blob/433f653387fd9eb5062db497e57cc2400e1e8a47/README.md#create-the-form-type-we-use-in-admin-to-fill-your-uielement), I've added documentation on attributes and examples.

The example UI Element, in the dist folder, is also updated to be declared via attributes.

And, i add a new maker command to generate the UI Element files:

![image](https://github.com/monsieurbiz/SyliusRichEditorPlugin/assets/465524/195194b9-3292-46d2-8129-8bd132097463)