### PR TITLE
Media manager compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,8 @@ setup_application:
 ${APP_DIR}/docker-compose.yaml:
 	rm -f ${APP_DIR}/docker-compose.yml
 	rm -f ${APP_DIR}/docker-compose.yaml
+	rm -f ${APP_DIR}/compose.yml
+	rm -f ${APP_DIR}/compose.override.dist.yml
 	ln -s ../../docker-compose.yaml.dist ${APP_DIR}/docker-compose.yaml
 .PHONY: ${APP_DIR}/docker-compose.yaml
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ And install the assets
 bin/console asset:install
 ```
 
+## Use it with the [Sylius Media Manager](https://github.com/monsieurbiz/SyliusMediaManagerPlugin/)
+
+You don't need to do something, everything is compatible.
+
+If you used the rich editor before using the media manager, you need to override the form theme of the media manager plugin :
+```
+mkdir -p templates/bundles/MonsieurBizSyliusMediaManagerPlugin/Admin/MediaManager/Form/;
+cp dist/templates/bundles/MonsieurBizSyliusMediaManagerPlugin/Admin/MediaManager/Form/_theme.html.twig templates/bundles/MonsieurBizSyliusMediaManagerPlugin/Admin/MediaManager/Form/_theme.html.twig;
+```
+
 ## Use the Rich Editor
 
 ### Update your form type

--- a/dist/templates/bundles/MonsieurBizSyliusMediaManagerPlugin/Admin/MediaManager/Form/_theme.html.twig
+++ b/dist/templates/bundles/MonsieurBizSyliusMediaManagerPlugin/Admin/MediaManager/Form/_theme.html.twig
@@ -1,0 +1,115 @@
+{% block monsieurbiz_sylius_media_manager_image_row %}
+    <div class="monsieurbiz-sylius-file-manager__image-field monsieurbiz-sylius-file-manager__field field">
+        {{- form_row(form, {'attr': {'style': 'display: none;', 'data-file-type': fileType}}) -}}
+        <div class="field">
+            <div class="monsieurbiz-sylius-file-manager__current" {%- if form.vars.value is empty -%}style="display: none;"{%- endif -%}>
+                <p>
+                    <small>{{ 'monsieurbiz_sylius_media_manager.ui.current_image' | trans }}</small><br />
+                    <img src="{{ form.vars.value ? monsieurbiz_richeditor_get_media_without_upload_dir(form.vars.value)|imagine_filter('monsieurbiz_sylius_media_manager_uploaded_image', {"relative_resize": {"widen": filterWidth }}) : '' }}" alt="" style="max-width: 300px;max-height: 300px;" />
+                </p>
+            </div>
+            <button type="button" class="ui button" onclick="monsieurbizSyliusMediaManagerChooseFile('{{ form.vars.full_name | escape('js') }}', '{{ form.vars.value | escape('js') }}', '{{ folder | escape('js') }}');">
+                {{ 'monsieurbiz_sylius_media_manager.ui.choose_image' | trans }}
+            </button>
+            <button type="button" class="monsieurbiz-sylius-file-manager__button-remove ui red button" onclick="monsieurbizSyliusMediaManagerRemoveFile('{{ form.vars.full_name | escape('js') }}', '{{ 'monsieurbiz_sylius_media_manager.ui.remove_confirmation' | trans | escape('js')}}');" {%- if form.vars.value is empty -%} style="display: none;"{%- endif -%}>
+                {{ 'monsieurbiz_sylius_media_manager.ui.remove_image' | trans }}
+            </button>
+        </div>
+    </div>
+{% endblock %}
+
+{% block monsieurbiz_sylius_media_manager_video_row %}{% if monsieurbiz_richeditor_file_extension_media_manager_exists() %}
+    {% set videoSrc = '' %}
+    {% if form.vars.value   %}
+        {% set videoSrc = get_media_manager_file_path(form.vars.value) %}
+            {% if not monsieurbiz_richeditor_file_exists(videoSrc) %}
+                {% set videoSrc = form.vars.value %}
+            {% endif %}
+        {% else %}
+            {% set videoSrc = form.vars.value %}
+        {% endif %}
+    {% endif %}
+    <div class="monsieurbiz-sylius-file-manager__video-field monsieurbiz-sylius-file-manager__field field">
+        {{- form_row(form, {'attr': {'style': 'display: none;', 'data-file-type': fileType}}) -}}
+        <div class="field">
+            <div class="monsieurbiz-sylius-file-manager__current" {%- if form.vars.value is empty -%}style="display: none;"{%- endif -%}>
+                <p>
+                    <small>{{ 'monsieurbiz_sylius_media_manager.ui.current_video' | trans }}</small><br />
+                     <video width="320" height="240" controls>
+                        <source src="{{ form.vars.value ? videoSrc : '' }}">
+                    </video>
+                </p>
+            </div>
+            <button type="button" class="ui button" onclick="monsieurbizSyliusMediaManagerChooseFile('{{ form.vars.full_name | escape('js') }}', '{{ form.vars.value | escape('js') }}', '{{ folder | escape('js') }}');">
+                {{ 'monsieurbiz_sylius_media_manager.ui.choose_video' | trans }}
+            </button>
+            <button type="button" class="monsieurbiz-sylius-file-manager__button-remove ui red button" onclick="monsieurbizSyliusMediaManagerRemoveFile('{{ form.vars.full_name | escape('js') }}', '{{ 'monsieurbiz_sylius_media_manager.ui.remove_confirmation' | trans | escape('js')}}');" {%- if form.vars.value is empty -%} style="display: none;"{%- endif -%}>
+                {{ 'monsieurbiz_sylius_media_manager.ui.remove_video' | trans }}
+            </button>
+        </div>
+    </div>
+{% endblock %}
+
+{% block monsieurbiz_sylius_media_manager_pdf_row %}
+    <div class="monsieurbiz-sylius-file-manager__file-field monsieurbiz-sylius-file-manager__field field">
+        {{- form_row(form, {'attr': {'style': 'display: none;', 'data-file-type': fileType}}) -}}
+        <div class="field">
+            <div class="monsieurbiz-sylius-file-manager__current" {%- if form.vars.value is empty -%}style="display: none;"{%- endif -%}>
+                <p>
+                    <small>{{ 'monsieurbiz_sylius_media_manager.ui.current_file' | trans }}</small><br />
+                    <a href="{{ form.vars.value ? get_media_manager_file_path(form.vars.value) : '' }}" target="_blank" rel="noopener noreferrer">
+                        {{ form.vars.value }}
+                    </a>
+                </p>
+            </div>
+            <button type="button" class="ui button" onclick="monsieurbizSyliusMediaManagerChooseFile('{{ form.vars.full_name | escape('js') }}', '{{ form.vars.value | escape('js') }}', '{{ folder | escape('js') }}');">
+                {{ 'monsieurbiz_sylius_media_manager.ui.choose_file' | trans }}
+            </button>
+            <button type="button" class="monsieurbiz-sylius-file-manager__button-remove ui red button" onclick="monsieurbizSyliusMediaManagerRemoveFile('{{ form.vars.full_name | escape('js') }}', '{{ 'monsieurbiz_sylius_media_manager.ui.remove_confirmation' | trans | escape('js')}}');" {%- if form.vars.value is empty -%} style="display: none;"{%- endif -%}>
+                {{ 'monsieurbiz_sylius_media_manager.ui.remove_file' | trans }}
+            </button>
+        </div>
+    </div>
+{% endblock %}
+
+{% block monsieurbiz_sylius_media_manager_favicon_row %}
+    <div class="monsieurbiz-sylius-file-manager__image-field monsieurbiz-sylius-file-manager__field field">
+        {{- form_row(form, {'attr': {'style': 'display: none;', 'data-file-type': fileType}}) -}}
+        <div class="field">
+            <div class="monsieurbiz-sylius-file-manager__current" {%- if form.vars.value is empty -%}style="display: none;"{%- endif -%}>
+                <p>
+                    <small>{{ 'monsieurbiz_sylius_media_manager.ui.current_image' | trans }}</small><br />
+                    <img src="{{ form.vars.value ? monsieurbiz_richeditor_get_media_without_upload_dir(form.vars.value)|imagine_filter('monsieurbiz_sylius_media_manager_uploaded_image', {"relative_resize": {"widen": filterWidth }}) : '' }}" alt="" style="max-width: 40px;max-height: 40px;" />
+                </p>
+            </div>
+            <button type="button" class="ui button" onclick="monsieurbizSyliusMediaManagerChooseFile('{{ form.vars.full_name | escape('js') }}', '{{ form.vars.value | escape('js') }}', '{{ folder | escape('js') }}');">
+                {{ 'monsieurbiz_sylius_media_manager.ui.choose_image' | trans }}
+            </button>
+            <button type="button" class="monsieurbiz-sylius-file-manager__button-remove ui red button" onclick="monsieurbizSyliusMediaManagerRemoveFile('{{ form.vars.full_name | escape('js') }}', '{{ 'monsieurbiz_sylius_media_manager.ui.remove_confirmation' | trans | escape('js')}}');" {%- if form.vars.value is empty -%} style="display: none;"{%- endif -%}>
+                {{ 'monsieurbiz_sylius_media_manager.ui.remove_image' | trans }}
+            </button>
+        </div>
+    </div>
+{% endblock %}
+
+{% block monsieurbiz_sylius_media_manager_audio_row %}
+    <div class="monsieurbiz-sylius-file-manager__audio-field monsieurbiz-sylius-file-manager__field field">
+        {{- form_row(form, {'attr': {'style': 'display: none;', 'data-file-type': fileType}}) -}}
+        <div class="field">
+            <div class="monsieurbiz-sylius-file-manager__current" {%- if form.vars.value is empty -%}style="display: none;"{%- endif -%}>
+                <p>
+                    <small>{{ 'monsieurbiz_sylius_media_manager.ui.current_file' | trans }}</small><br />
+                    <audio controls src="{{ form.vars.value ? get_media_manager_file_path(form.vars.value) : '' }}">
+                        <a href="{{ form.vars.value ? get_media_manager_file_path(form.vars.value) : '' }}">{{ 'monsieurbiz_sylius_media_manager.ui.current_file' | trans }}</a>
+                    </audio>
+                </p>
+            </div>
+            <button type="button" class="ui button" onclick="monsieurbizSyliusMediaManagerChooseFile('{{ form.vars.full_name | escape('js') }}', '{{ form.vars.value | escape('js') }}', '{{ folder | escape('js') }}');">
+                {{ 'monsieurbiz_sylius_media_manager.ui.choose_file' | trans }}
+            </button>
+            <button type="button" class="monsieurbiz-sylius-file-manager__button-remove ui red button" onclick="monsieurbizSyliusMediaManagerRemoveFile('{{ form.vars.full_name | escape('js') }}', '{{ 'monsieurbiz_sylius_media_manager.ui.remove_confirmation' | trans | escape('js')}}');" {%- if form.vars.value is empty -%} style="display: none;"{%- endif -%}>
+                {{ 'monsieurbiz_sylius_media_manager.ui.remove_file' | trans }}
+            </button>
+        </div>
+    </div>
+{% endblock %}

--- a/dist/templates/bundles/MonsieurBizSyliusMediaManagerPlugin/Admin/MediaManager/Form/_theme.html.twig
+++ b/dist/templates/bundles/MonsieurBizSyliusMediaManagerPlugin/Admin/MediaManager/Form/_theme.html.twig
@@ -18,12 +18,13 @@
     </div>
 {% endblock %}
 
-{% block monsieurbiz_sylius_media_manager_video_row %}{% if monsieurbiz_richeditor_file_extension_media_manager_exists() %}
+{% block monsieurbiz_sylius_media_manager_video_row %}
     {% set videoSrc = '' %}
-    {% if form.vars.value   %}
-        {% set videoSrc = get_media_manager_file_path(form.vars.value) %}
+    {% if form.vars.value %}
+        {% if monsieurbiz_richeditor_file_extension_media_manager_exists() %}
+            {% set videoSrc = get_media_manager_file_path(form.vars.value) %}
             {% if not monsieurbiz_richeditor_file_exists(videoSrc) %}
-                {% set videoSrc = form.vars.value %}
+                {% set videoSrc = form.vars.value%}
             {% endif %}
         {% else %}
             {% set videoSrc = form.vars.value %}

--- a/src/Form/Constraints/RichEditorConstraints.php
+++ b/src/Form/Constraints/RichEditorConstraints.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace MonsieurBiz\SyliusRichEditorPlugin\Form\Constraints;
 
+use MonsieurBiz\SyliusRichEditorPlugin\MonsieurBizSyliusRichEditorPlugin;
 use Symfony\Component\Validator\Constraints as Assert;
 
 final class RichEditorConstraints
@@ -24,6 +25,10 @@ final class RichEditorConstraints
      */
     public static function getImageConstraints(array $data, string $fieldName, bool $required = true, array $defaultConstraints = []): array
     {
+        if (MonsieurBizSyliusRichEditorPlugin::imageMediaManagerExists()) {
+            return self::getMediaManagerConstraints($required, $defaultConstraints);
+        }
+
         if (empty($defaultConstraints)) {
             $defaultConstraints = [
                 new Assert\Image([]),
@@ -40,6 +45,10 @@ final class RichEditorConstraints
      */
     public static function getVideoConstraints(array $data, string $fieldName, bool $required = true, array $defaultConstraints = []): array
     {
+        if (MonsieurBizSyliusRichEditorPlugin::videoMediaManagerExists()) {
+            return self::getMediaManagerConstraints($required, $defaultConstraints);
+        }
+
         if (empty($defaultConstraints)) {
             $defaultConstraints = [
                 new Assert\File([
@@ -58,6 +67,18 @@ final class RichEditorConstraints
             return [];
         }
 
+        if (!$required) {
+            return $constraints;
+        }
+
+        // No file set yet, we require file
+        $constraints[] = new Assert\NotBlank([]);
+
+        return $constraints;
+    }
+
+    private static function getMediaManagerConstraints(bool $required, array $constraints): array
+    {
         if (!$required) {
             return $constraints;
         }

--- a/src/Form/Type/UiElement/ImageType.php
+++ b/src/Form/Type/UiElement/ImageType.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace MonsieurBiz\SyliusRichEditorPlugin\Form\Type\UiElement;
 
+use MonsieurBiz\SyliusMediaManagerPlugin\Form\Type\ImageType as MediaManagerImageType;
 use MonsieurBiz\SyliusRichEditorPlugin\Form\Constraints\RichEditorConstraints;
 use MonsieurBiz\SyliusRichEditorPlugin\Form\Type\AlignmentType;
+use MonsieurBiz\SyliusRichEditorPlugin\MonsieurBizSyliusRichEditorPlugin;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextType as FormTextType;
@@ -37,7 +39,7 @@ class ImageType extends AbstractType
     public function addFields(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('image', FileType::class, [
+            ->add('image', $this->getImageType(), [
                 'label' => 'monsieurbiz_richeditor_plugin.ui_element.monsieurbiz.image.field.image',
                 'data_class' => null,
                 'required' => true,
@@ -69,13 +71,19 @@ class ImageType extends AbstractType
         ;
     }
 
+    private function getImageType(): string
+    {
+        // @phpstan-ignore-next-line
+        return MonsieurBizSyliusRichEditorPlugin::imageMediaManagerExists() ? MediaManagerImageType::class : FileType::class;
+    }
+
     public function addEvents(FormBuilderInterface $builder, array $options): void
     {
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
             // Change image field constraints depending on submitted value
             $options = $event->getForm()->get('image')->getConfig()->getOptions();
             $options['constraints'] = RichEditorConstraints::getImageConstraints($event->getData(), 'image');
-            $event->getForm()->add('image', FileType::class, $options);
+            $event->getForm()->add('image', $this->getImageType(), $options);
         });
     }
 }

--- a/src/Form/Type/UiElement/VideoType.php
+++ b/src/Form/Type/UiElement/VideoType.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace MonsieurBiz\SyliusRichEditorPlugin\Form\Type\UiElement;
 
+use MonsieurBiz\SyliusMediaManagerPlugin\Form\Type\ImageType as MediaManagerImageType;
+use MonsieurBiz\SyliusMediaManagerPlugin\Form\Type\VideoType as MediaManagerVideoType;
 use MonsieurBiz\SyliusRichEditorPlugin\Form\Constraints\RichEditorConstraints;
 use MonsieurBiz\SyliusRichEditorPlugin\Form\Type\AlignmentType;
+use MonsieurBiz\SyliusRichEditorPlugin\MonsieurBizSyliusRichEditorPlugin;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -35,13 +38,13 @@ class VideoType extends AbstractType
     public function addFields(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('video', FileType::class, [
+            ->add('video', $this->getVideoType(), [
                 'label' => 'monsieurbiz_richeditor_plugin.ui_element.monsieurbiz.video.field.video',
                 'data_class' => null,
                 'required' => true,
                 'attr' => ['data-video' => 'true'],
             ])
-            ->add('image', FileType::class, [
+            ->add('image', $this->getImageType(), [
                 'label' => 'monsieurbiz_richeditor_plugin.ui_element.monsieurbiz.video.field.image',
                 'data_class' => null,
                 'required' => false,
@@ -51,18 +54,30 @@ class VideoType extends AbstractType
         ;
     }
 
+    private function getImageType(): string
+    {
+        // @phpstan-ignore-next-line
+        return MonsieurBizSyliusRichEditorPlugin::imageMediaManagerExists() ? MediaManagerImageType::class : FileType::class;
+    }
+
+    private function getVideoType(): string
+    {
+        // @phpstan-ignore-next-line
+        return MonsieurBizSyliusRichEditorPlugin::videoMediaManagerExists() ? MediaManagerVideoType::class : FileType::class;
+    }
+
     public function addEvents(FormBuilderInterface $builder, array $options): void
     {
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
             // Change video field constraints depending on submitted value
             $options = $event->getForm()->get('video')->getConfig()->getOptions();
             $options['constraints'] = RichEditorConstraints::getVideoConstraints($event->getData(), 'video');
-            $event->getForm()->add('video', FileType::class, $options);
+            $event->getForm()->add('video', $this->getVideoType(), $options);
 
             // Change image field constraints depending on submitted value
             $options = $event->getForm()->get('image')->getConfig()->getOptions();
             $options['constraints'] = RichEditorConstraints::getImageConstraints($event->getData(), 'image', false);
-            $event->getForm()->add('image', FileType::class, $options);
+            $event->getForm()->add('image', $this->getImageType(), $options);
         });
     }
 }

--- a/src/MonsieurBizSyliusRichEditorPlugin.php
+++ b/src/MonsieurBizSyliusRichEditorPlugin.php
@@ -51,4 +51,19 @@ final class MonsieurBizSyliusRichEditorPlugin extends Bundle
         parent::build($container);
         $container->addCompilerPass(new UiElementRegistryPass());
     }
+
+    public static function imageMediaManagerExists(): bool
+    {
+        return class_exists('MonsieurBiz\SyliusMediaManagerPlugin\Form\Type\ImageType');
+    }
+
+    public static function videoMediaManagerExists(): bool
+    {
+        return class_exists('MonsieurBiz\SyliusMediaManagerPlugin\Form\Type\VideoType');
+    }
+
+    public static function fileExtensionMediaManagerExists(): bool
+    {
+        return class_exists('MonsieurBiz\SyliusMediaManagerPlugin\Twig\Extension\FileExtension');
+    }
 }

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -8,6 +8,7 @@ services:
             string $monsieurbizRicheditorDefaultElement: '%monsieurbiz.richeditor.config.default_element%'
             string $monsieurbizRicheditorDefaultElementDataField: '%monsieurbiz.richeditor.config.default_element_data_field%'
             string $monsieurbizRicheditorUploadDirectory: '%monsieurbiz.richeditor.config.upload_directory%'
+            string $monsieurbizRicheditorKernelPublicDir: '%kernel.project_dir%/public'
             Gaufrette\FilesystemInterface $filesystem: '@gaufrette.monsieurbiz_rich_editor_fixture_file_filesystem'
 
     MonsieurBiz\SyliusRichEditorPlugin\Controller\:

--- a/src/Resources/views/Admin/UiElement/video.html.twig
+++ b/src/Resources/views/Admin/UiElement/video.html.twig
@@ -7,8 +7,16 @@
         align
 #}
 {% set align = element.align is defined and element.align is not empty ? element.align : 'inherit' %}
+{% if monsieurbiz_richeditor_file_extension_media_manager_exists() %}
+    {% set videoSrc = get_media_manager_file_path(element.video) %}
+    {% if not monsieurbiz_richeditor_file_exists(videoSrc) %}
+        {% set videoSrc = element.video %}
+    {% endif %}
+{% else %}
+    {% set videoSrc = element.video %}
+{% endif %}
 <div style="text-align: {{align}};">
     <video width="100%" poster="{{ monsieurbiz_richeditor_get_media_without_upload_dir(element.image)|imagine_filter('monsieurbiz_rich_editor_image') }}" controls>
-        <source src="{{ element.video }}" type="video/{{ element.video|split('.')|last }}">
+        <source src="{{ videoSrc }}" type="video/{{ element.video|split('.')|last }}">
     </video>
 </div>

--- a/src/Resources/views/Shop/UiElement/video.html.twig
+++ b/src/Resources/views/Shop/UiElement/video.html.twig
@@ -7,8 +7,16 @@
         align
 #}
 {% set align = element.align is defined and element.align is not empty ? element.align : 'inherit' %}
+{% if monsieurbiz_richeditor_file_extension_media_manager_exists() %}
+    {% set videoSrc = get_media_manager_file_path(element.video) %}
+    {% if not monsieurbiz_richeditor_file_exists(videoSrc) %}
+        {% set videoSrc = element.video %}
+    {% endif %}
+{% else %}
+    {% set videoSrc = element.video %}
+{% endif %}
 <div style="text-align: {{align}};">
     <video width="100%" poster="{{ monsieurbiz_richeditor_get_media_without_upload_dir(element.image)|imagine_filter('monsieurbiz_rich_editor_image') }}" controls>
-        <source src="{{ element.video }}" type="video/{{ element.video|split('.')|last }}">
+        <source src="{{ videoSrc }}" type="video/{{ element.video|split('.')|last }}">
     </video>
 </div>

--- a/src/Twig/RichEditorExtension.php
+++ b/src/Twig/RichEditorExtension.php
@@ -79,7 +79,11 @@ final class RichEditorExtension extends AbstractExtension
      */
     public function getFunctions(): array
     {
-        return [
+        $mediaManagerTwigExtension = $this->fileExtensionMediaManagerExists() ? [] : [
+            new TwigFunction('get_media_manager_file_path', [$this, 'getMediaManagerFilePath'], ['is_safe' => ['html', 'js']]),
+        ];
+
+        return array_merge([
             new TwigFunction('monsieurbiz_richeditor_list_elements', [$this, 'listUiElements'], ['is_safe' => ['html', 'js']]),
             new TwigFunction('monsieurbiz_richeditor_youtube_link', [$this, 'convertYoutubeEmbeddedLink'], ['is_safe' => ['html', 'js']]),
             new TwigFunction('monsieurbiz_richeditor_youtube_id', [$this, 'getYoutubeIdFromLink'], ['is_safe' => ['html', 'js']]),
@@ -90,7 +94,7 @@ final class RichEditorExtension extends AbstractExtension
             new TwigFunction('monsieurbiz_richeditor_get_media_without_upload_dir', [$this, 'getMediaWithoutUploadDir'], ['is_safe' => ['html', 'js']]),
             new TwigFunction('monsieurbiz_richeditor_file_extension_media_manager_exists', [$this, 'fileExtensionMediaManagerExists'], ['is_safe' => ['html', 'js']]),
             new TwigFunction('monsieurbiz_richeditor_file_exists', [$this, 'fileExists'], ['is_safe' => ['html', 'js']]),
-        ];
+        ], $mediaManagerTwigExtension);
     }
 
     /**
@@ -267,6 +271,12 @@ final class RichEditorExtension extends AbstractExtension
     public function fileExists(string $path): bool
     {
         return file_exists($this->kernelPublicDir . $path);
+    }
+
+    // Fall back for twig linter if the media manager is not installed
+    public function getMediaManagerFilePath(string $path): string
+    {
+        return $path;
     }
 
     private function isAdmin(array $context): bool

--- a/src/Twig/RichEditorExtension.php
+++ b/src/Twig/RichEditorExtension.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace MonsieurBiz\SyliusRichEditorPlugin\Twig;
 
 use MonsieurBiz\SyliusRichEditorPlugin\Exception\UiElementNotFoundException;
+use MonsieurBiz\SyliusRichEditorPlugin\MonsieurBizSyliusRichEditorPlugin;
 use MonsieurBiz\SyliusRichEditorPlugin\UiElement\RegistryInterface;
 use MonsieurBiz\SyliusRichEditorPlugin\Validator\Constraints\YoutubeUrlValidator;
 use Symfony\Bridge\Twig\AppVariable;
@@ -40,6 +41,8 @@ final class RichEditorExtension extends AbstractExtension
 
     private string $uploadDirectory;
 
+    private string $kernelPublicDir;
+
     /**
      * RichEditorExtension constructor.
      */
@@ -48,13 +51,15 @@ final class RichEditorExtension extends AbstractExtension
         Environment $twig,
         string $monsieurbizRicheditorDefaultElement,
         string $monsieurbizRicheditorDefaultElementDataField,
-        string $monsieurbizRicheditorUploadDirectory
+        string $monsieurbizRicheditorUploadDirectory,
+        string $monsieurbizRicheditorKernelPublicDir
     ) {
         $this->uiElementRegistry = $uiElementRegistry;
         $this->twig = $twig;
         $this->defaultElement = $monsieurbizRicheditorDefaultElement;
         $this->defaultElementDataField = $monsieurbizRicheditorDefaultElementDataField;
         $this->uploadDirectory = $monsieurbizRicheditorUploadDirectory;
+        $this->kernelPublicDir = $monsieurbizRicheditorKernelPublicDir;
     }
 
     /**
@@ -83,6 +88,8 @@ final class RichEditorExtension extends AbstractExtension
             new TwigFunction('monsieurbiz_richeditor_get_default_element_data_field', [$this, 'getDefaultElementDataField'], ['is_safe' => ['html']]),
             new TwigFunction('monsieurbiz_richeditor_get_current_file_path', [$this, 'getCurrentFilePath'], ['needs_context' => true, 'is_safe' => ['html']]),
             new TwigFunction('monsieurbiz_richeditor_get_media_without_upload_dir', [$this, 'getMediaWithoutUploadDir'], ['is_safe' => ['html', 'js']]),
+            new TwigFunction('monsieurbiz_richeditor_file_extension_media_manager_exists', [$this, 'fileExtensionMediaManagerExists'], ['is_safe' => ['html', 'js']]),
+            new TwigFunction('monsieurbiz_richeditor_file_exists', [$this, 'fileExists'], ['is_safe' => ['html', 'js']]),
         ];
     }
 
@@ -250,6 +257,16 @@ final class RichEditorExtension extends AbstractExtension
         }
 
         return $path;
+    }
+
+    public function fileExtensionMediaManagerExists(): bool
+    {
+        return MonsieurBizSyliusRichEditorPlugin::fileExtensionMediaManagerExists();
+    }
+
+    public function fileExists(string $path): bool
+    {
+        return file_exists($this->kernelPublicDir . $path);
     }
 
     private function isAdmin(array $context): bool


### PR DESCRIPTION
Depending on #224 

## Demo

The first part of the demo shows the rich editor image management without Media Manager.
Then I required the plugin and reload the page.
Everything is compatible, and automatically switch to the media manager.
The second part of the video shows an image setup and a video element setup.

https://github.com/monsieurbiz/SyliusRichEditorPlugin/assets/11380627/ff33cc31-9e2d-4f8c-9345-5ee1ce0c1757

## Case when the Media manager installed but content was saved before the use of it

You don't need to do something, everything is compatible as shown in the video.

If you want the form compatible, you need to copy the overriden form theme https://github.com/monsieurbiz/SyliusRichEditorPlugin/pull/221/commits/f036d6ae2f8150bc354f68ba241fae8dc4b03406

Else the preview image will not be shown.




