### PR TITLE
Add classes and prototype name in image collection element

### DIFF
--- a/src/Form/Type/UiElement/ImageCollectionType.php
+++ b/src/Form/Type/UiElement/ImageCollectionType.php
@@ -26,6 +26,7 @@ class ImageCollectionType extends AbstractType
     {
         $builder->add('images', CollectionType::class, [
             'entry_type' => ImageType::class,
+            'prototype_name' => '__image__',
             'button_add_label' => 'monsieurbiz_richeditor_plugin.form.add_image',
             'allow_add' => true,
             'allow_delete' => true,

--- a/src/Form/Type/UiElement/ImageCollectionType.php
+++ b/src/Form/Type/UiElement/ImageCollectionType.php
@@ -33,6 +33,9 @@ class ImageCollectionType extends AbstractType
             'by_reference' => false,
             'delete_empty' => true,
             'label' => 'monsieurbiz_richeditor_plugin.ui_element.monsieurbiz.image_collection.field.images',
+            'attr' => [
+                'class' => 'ui segment secondary collection--flex',
+            ],
         ]);
     }
 }


### PR DESCRIPTION
## Update collection type to have prototype name

To avoid issue with collection forms javascript

## Add some classes on image collection type

In order to have display in a special segment

![image](https://github.com/monsieurbiz/SyliusRichEditorPlugin/assets/11380627/2e4b3a1c-1650-4803-bd31-c407824729d3)

Also you have specific class to customize the display of it with `collection--flex`

For example you can add this to have flex display of your elements

```

.collection--flex > div {
    display: flex;
    flex-flow: wrap;
}

.collection--flex > div > div {
    margin-right: 10px;
}
```

![image](https://github.com/monsieurbiz/SyliusRichEditorPlugin/assets/11380627/e1715158-e203-4d68-884d-11fb64e8ebc2)
