### PR TITLE
Add MonsieurBizRichEditorWysiwyg for retro-compatibility

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -8,6 +8,24 @@ const initEditors = (target) => {
   suneditor.init(target);
 }
 
+// For retro-compatibility we kee the MonsieurBizRichEditorWysiwyg class
+// But now it use new initEditors function
+global.MonsieurBizRichEditorWysiwyg = class {
+  constructor(config) {}
+  load(container) {
+      initEditors(container);
+  }
+
+  setupEditor(target) {
+    if (null === target.parent) {
+      return;
+    }
+    initEditors(target.parent);
+  }
+}
+
+
+
 document.addEventListener('DOMContentLoaded', function () {
   const target = document.querySelector('body');
   initEditors(target);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -15,7 +15,6 @@ global.MonsieurBizRichEditorWysiwyg = class {
   load(container) {
       initEditors(container);
   }
-
   setupEditor(target) {
     if (null === target.parent) {
       return;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -24,8 +24,6 @@ global.MonsieurBizRichEditorWysiwyg = class {
   }
 }
 
-
-
 document.addEventListener('DOMContentLoaded', function () {
   const target = document.querySelector('body');
   initEditors(target);


### PR DESCRIPTION
This small fix should avoid error when `MonsieurBizRichEditorWysiwyg` is used on project to enabled WYSIWYG after page content reload.