### PR TITLE
fix(maker): Fix icon argument usage in UiElementMaker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
             "assets:install %PUBLIC_DIR%": "symfony-cmd"
         },
         "phpcs": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix --using-cache=no",
-        "phpstan": "phpstan analyse -c phpstan.neon src/",
+        "phpstan": "phpstan analyse -c phpstan.neon",
         "phpmd": "phpmd --exclude Migrations/* src/ ansi phpmd.xml",
         "phpunit": "phpunit",
         "phpspec": "phpspec run"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,7 @@
 parameters:
     level: 8
     paths:
-        - %rootDir%/src/
+        - src/
 
     excludePaths:
         # Makes PHPStan crash

--- a/src/Maker/UiElementMaker.php
+++ b/src/Maker/UiElementMaker.php
@@ -39,7 +39,7 @@ final class UiElementMaker extends AbstractMaker
     {
         $command
             ->addArgument('code', InputArgument::OPTIONAL, 'The code of the UI Element (e.g. <fg=yellow>my_ui_element</>)')
-            ->addArgument('icon', InputArgument::OPTIONAL, 'The semantic icon code for the UI Element (e.g. <fg=yellow>map pin</>)')
+            ->addArgument('icon', InputArgument::OPTIONAL, 'The semantic icon code for the UI Element (e.g. <fg=yellow>map pin</>)', 'square')
             ->addArgument('code_prefix', InputArgument::OPTIONAL, 'The code prefix for the UI Element (e.g. <fg=yellow>app</>)', 'app')
             ->setDescription('Creates a new UI Element FormType and templates')
         ;
@@ -48,6 +48,7 @@ final class UiElementMaker extends AbstractMaker
     public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
     {
         $code = $input->getArgument('code');
+        $icon = $input->getArgument('icon');
         $codePrefix = $input->getArgument('code_prefix');
         Assert::string($code);
         $name = Str::asCamelCase($code);
@@ -61,7 +62,7 @@ final class UiElementMaker extends AbstractMaker
             __DIR__ . '/../Resources/skeleton/UiElementFormType.tpl.php',
             [
                 'code' => \sprintf('%s.%s', $codePrefix, $code),
-                'icon' => 'map pin',
+                'icon' => $icon,
                 'tags' => json_encode([]),
             ]
         );


### PR DESCRIPTION
Despite specifying `icon` argument on `make:ui-element` command, the generated class contained always `map pin` icon name.
The argument was not used in `UiElementMaker` class. 

This PR fix it, and set `square` as neutral default icon, WDYT?

> [!WARNING]
> I reduced the PHPStan level from `max` to `8`, because `max` level (currently `9`) only brings constraint about `mixed` type which is more annoying than useful. Even PHPStan itself is configured to `8` (https://github.com/phpstan/phpstan-src/blob/1.12.x/build/phpstan.neon#L14)