### PR TITLE
fix(twig): Handle preview page of SyliusCmsPagePlugin render

### DIFF
--- a/src/Twig/RichEditorExtension.php
+++ b/src/Twig/RichEditorExtension.php
@@ -292,6 +292,11 @@ final class RichEditorExtension extends AbstractExtension
             return false;
         }
 
+        // If we are on the SyliusCmsPagePlugin preview page, we need to load Shop templates.
+        if ('monsieurbiz_cms_page_admin_page_preview' === $request->get('_route')) {
+            return false;
+        }
+
         return self::ADMIN_FIREWALL_CONTEXT === $request->get('_firewall_context');
     }
 }

--- a/src/Twig/RichEditorExtension.php
+++ b/src/Twig/RichEditorExtension.php
@@ -31,6 +31,8 @@ final class RichEditorExtension extends AbstractExtension
 {
     private const ADMIN_FIREWALL_CONTEXT = 'security.firewall.map.context.admin';
 
+    private const SYLIUS_ADMIN_SECTION = 'admin';
+
     private RegistryInterface $uiElementRegistry;
 
     private Environment $twig;
@@ -284,6 +286,9 @@ final class RichEditorExtension extends AbstractExtension
         return $path;
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
     private function isAdmin(array $context): bool
     {
         /** @var ?AppVariable $app */
@@ -292,11 +297,19 @@ final class RichEditorExtension extends AbstractExtension
             return false;
         }
 
-        // If we are on the SyliusCmsPagePlugin preview page, we need to load Shop templates.
-        if ('monsieurbiz_cms_page_admin_page_preview' === $request->get('_route')) {
-            return false;
+        // Check Sylius section to know if we are in the admin
+        /** @var ?array $sylius */
+        $sylius = $request->get('_sylius');
+        if (isset($sylius['section'])) {
+            return self::SYLIUS_ADMIN_SECTION === $sylius['section'];
         }
 
-        return self::ADMIN_FIREWALL_CONTEXT === $request->get('_firewall_context');
+        // Check firewall context to know if we are in the admin
+        if ($request->attributes->has('_firewall_context')) {
+            return self::ADMIN_FIREWALL_CONTEXT === $request->attributes->get('_firewall_context');
+        }
+
+        // False by default
+        return false;
     }
 }


### PR DESCRIPTION
If https://github.com/monsieurbiz/SyliusCmsPagePlugin is installed alongside this plugin, we need to take care of the theme templates on the preview page and not load the Admin template of each Element, but the Shop template.

See the related PR https://github.com/monsieurbiz/SyliusCmsPagePlugin/pull/75