### PR TITLE
Add current locale on submit to display preview in right version

### DIFF
--- a/src/Controller/FormController.php
+++ b/src/Controller/FormController.php
@@ -151,14 +151,22 @@ class FormController extends AbstractController
 
     /**
      * Validate submitted data and return an UI Element JSON if everything is OK.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
-    public function submitAction(Request $request, FileUploaderInterface $fileUploader, string $code, bool $isEdition): Response
+    public function submitAction(Request $request, FileUploaderInterface $fileUploader, SwitchAdminLocaleInterface $switchAdminLocale, string $code, bool $isEdition): Response
     {
         // Find UI Element from type
         try {
             $uiElement = $this->uiElementRegistry->getUiElement($code);
         } catch (UiElementNotFoundException $exception) {
             throw $this->createNotFoundException($exception->getMessage());
+        }
+
+        // if we have a locale value in the post data, we change the current
+        // admin locale to make the ui elements in the correct version.
+        if (($locale = $request->get('locale')) && \is_string($locale)) {
+            $switchAdminLocale->switchLocale($locale);
         }
 
         // Create and validate form

--- a/src/Resources/views/Admin/form.html.twig
+++ b/src/Resources/views/Admin/form.html.twig
@@ -32,5 +32,6 @@
     </div>
 </div>
 <div class="uie-panels__inner ui segment form">
-    {{ form(form, {'action': url('monsieurbiz_richeditor_admin_form_submit', {'code': uiElement.code, 'isEdition': isEdition})}) }}
+    {% set locale = form.vars.attr['data-locale']|default(sylius.localeCode) %}
+    {{ form(form, {'action': url('monsieurbiz_richeditor_admin_form_submit', {'code': uiElement.code, 'isEdition': isEdition, 'locale': locale})}) }}
 </div>


### PR DESCRIPTION
Continuation of PR #244, add locale when submitting form to display block preview according to current locale.

![image](https://github.com/user-attachments/assets/c1b815d7-43e6-4bef-8461-8b85d95bc690)